### PR TITLE
Make variant color/symbol optional

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2711,6 +2711,8 @@ Weakpoints only match if they share the same id, so it's important to define the
     "name": { "str": "Variant A" },             // The name used instead of the default name when this variant is selected
     "description": "A fancy variant A",         // The description used instead of the default when this variant is selected
     "ascii_picture": "valid_ascii_art_id",      // An ASCII art picture used when this variant is selected. If there is none, the default (if it exists) is used.
+    "symbol": "/",                              // Valid unicode character to replace the item symbol. If not specified, no change will be made.
+    "color": "red",                             // Replacement color of item symbol. If not specified, no change will be made.
     "weight": 2,                                // The relative chance of this variant being selected over other variants when this item is spawned with no explicit variant. Defaults to 0. If it is 0, this variant will not be selected
     "append": true                              // If this description should just be appended to the base item description instead of completely overwriting it.
   }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5474,8 +5474,8 @@ int item::engine_displacement() const
 
 const std::string &item::symbol() const
 {
-    if( has_itype_variant() ) {
-        return _itype_variant->alt_sym;
+    if( has_itype_variant() && _itype_variant->alt_sym ) {
+        return *_itype_variant->alt_sym;
     }
     return type->sym;
 }
@@ -6345,8 +6345,8 @@ nc_color item::color() const
     if( is_corpse() ) {
         return corpse->color;
     }
-    if( has_itype_variant() ) {
-        return _itype_variant->alt_color;
+    if( has_itype_variant() && _itype_variant->alt_color ) {
+        return *_itype_variant->alt_color;
     }
     return type->color;
 }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2490,9 +2490,7 @@ void itype_variant_data::load( const JsonObject &jo )
     mandatory( jo, false, "id", id );
     mandatory( jo, false, "name", alt_name );
     mandatory( jo, false, "description", alt_description );
-    if( jo.has_string( "symbol" ) ) {
-        alt_sym = jo.get_string( "symbol" );
-    }
+    optional( jo, false, "symbol", alt_sym, cata::nullopt );
     if( jo.has_string( "color" ) ) {
         alt_color = color_from_string( jo.get_string( "color" ) );
     }

--- a/src/itype.h
+++ b/src/itype.h
@@ -618,8 +618,8 @@ struct itype_variant_data {
     translation alt_name;
     translation alt_description;
     ascii_art_id art;
-    std::string alt_sym;
-    nc_color alt_color = c_white;
+    cata::optional<std::string> alt_sym;
+    cata::optional<nc_color> alt_color = cata::nullopt;
 
     bool append = false; // if the description should be appended to the base description.
 


### PR DESCRIPTION
Not every variant should need to specify these, so let's make them optional. Also, add docs.